### PR TITLE
Rename referenced_unit to unit.

### DIFF
--- a/app/components/data-menu/layer-directives/eventseries-directive.js
+++ b/app/components/data-menu/layer-directives/eventseries-directive.js
@@ -43,7 +43,7 @@ angular.module('data-menu')
             quantity: response.observation_type
               && response.observation_type.parameter,
             unit: response.observation_type
-              && response.observation_type.referenced_unit
+              && response.observation_type.unit
           }));
 
           MapService.updateLayers([scope.layer]);


### PR DESCRIPTION
See my comment https://github.com/DigitaleDeltaOrg/DD-viewer/pull/1: `response.observation_type.referenced_unit` should be `response.observation_type.unit`.